### PR TITLE
Add -p to mkdir, allow for DESTDIR

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,8 +13,8 @@ demo_DATA = demo/genomicVs_with_primers.fasta demo/genomicDs.fasta demo/genomicJ
 man_MANS = igor.1
 
 install-data-local:
-	mkdir $(pkgdatadir)/models
-	cp -r models/* $(pkgdatadir)/models
+	mkdir -p $(DESTDIR)$(pkgdatadir)/models
+	cp -r models/* $(DESTDIR)$(pkgdatadir)/models
 
 uninstall-local:
 	rm -rf $(pkgdatadir)/models 


### PR DESCRIPTION
Hello,
The mkdir fails when both igor and its subdirectoy models are to be created in /usr/share, hence the -p. When using igor from a chroot directory (or when preparing a package for Debian/Ubuntu) it is common to set the DESTDIR as a prefix to the installation directory.
Many thanks and regards,
Steffen