### PR TITLE
Choose the number N of scenarios in the output

### DIFF
--- a/igor_src/main.cpp
+++ b/igor_src/main.cpp
@@ -767,7 +767,7 @@ int main(int argc , char* argv[]){
 						return terminate_IGoR_with_error_message("Number of scenarios to be recorded must be greater than zero");
 					}
 
-					shared_ptr<Counter>best_sc_ptr(new Best_scenarios_counter(10 , cl_path + "output/" ,true));
+					shared_ptr<Counter>best_sc_ptr(new Best_scenarios_counter(n_record_scenarios , cl_path + "output/" ,true));
 					cl_counters_list.emplace(cl_counters_list.size(),best_sc_ptr);
 				}
 				else if(string(argv[carg_i]) == "--coverage"){


### PR DESCRIPTION
The command-line option "--N" for the "-output" was not effective, due to a bug in the code. I've substituted "n_record_scenarios" to "10" into line 770, so that the user choice for N is effective in the code.