### PR TITLE
Pygor - Small fix bestscenarios

### DIFF
--- a/pygor/pygor/counters/bestscenarios/bestscenarios.py
+++ b/pygor/pygor/counters/bestscenarios/bestscenarios.py
@@ -65,6 +65,11 @@ def scenarios_indices2values(best_scenarios, input_genmodel,
             best_scenarios_real[event.name] = tmp_real_indices.apply(
                 lambda x: real_vect[x])
 
+            # Mapping the arrays to list to fix CSV file exporting issues
+            if event.event_type == "DinucMarkov":
+                best_scenarios_real[event.name] = \
+                    list(map(list, best_scenarios_real[event.name]))
+
             # Return possible errors and mismatches as a list of positions
             if best_scenarios_real.columns.contains("Errors"):
                 best_scenarios_real["Errors"] = best_scenarios[


### PR DESCRIPTION
Small fix for bestscenarios: 'DinucMarkov' numpy arrays are not converting to lists properly when they are export to a CSV file from the pandas dataframe. Comma separators are removed in such scenario and some of the rows have double quotation marks randomly positioned in the row.